### PR TITLE
Fixed some basic DX11 shader warnings

### DIFF
--- a/ShaderEditor/Assets/StrumpyShaderEditor/Editor/Resources/Internal/ShaderTemplate.template
+++ b/ShaderEditor/Assets/StrumpyShaderEditor/Editor/Resources/Internal/ShaderTemplate.template
@@ -58,6 +58,7 @@ ${LightingFunctionPrePass}
 			};
 
 			void vert (inout appdata_full v, out Input o) {
+				UNITY_INITIALIZE_OUTPUT(Input,o)
 ${VertexShader}
 ${VertexShaderMods}
 			}


### PR DESCRIPTION
Added UNITY_INITIALIZE_OUTPUT(Input,o) to the vertex function of the template shader. Possible changes in line endings not intended.
